### PR TITLE
Trusty patches upstream

### DIFF
--- a/include/evmm_desc.h
+++ b/include/evmm_desc.h
@@ -83,6 +83,11 @@ typedef struct {
 } optee_desc_t;
 
 typedef struct {
+	module_file_info_t tee_file;
+	void* dev_sec_info;
+} tee_desc_t;
+
+typedef struct {
 	uint8_t num_of_cpu; /* filled in stage0/1 */
 	uint8_t pad[3];
 	uint32_t sipi_ap_wkup_addr; /* filled in stage0 */
@@ -98,6 +103,10 @@ typedef struct {
 
 #ifdef MODULE_TEMPLATE_TEE
 	uint64_t x64_cr3;
+#endif
+
+#ifdef MODULE_TRUSTY_TEE
+	tee_desc_t trusty_tee_desc;
 #endif
 
 #ifdef MODULE_TRUSTY_GUEST

--- a/include/file_pack.h
+++ b/include/file_pack.h
@@ -22,7 +22,7 @@ enum {
 	STAGE1_BIN_INDEX,
 	EVMM_BIN_INDEX,
 
-#if defined (MODULE_TRUSTY_GUEST) && defined (PACK_LK)
+#if (defined (MODULE_TRUSTY_GUEST) || defined (MODULE_TRUSTY_TEE)) && defined (PACK_LK)
 	LK_BIN_INDEX,
 #endif
 

--- a/include/vmm_asm.h
+++ b/include/vmm_asm.h
@@ -908,4 +908,7 @@ static inline void asm_perform_iret(void)
 		::: "rax", "rbx", "rcx", "rdx"
 	);
 }
+
+#define barrier() __asm__ __volatile__("" ::: "memory")
+
 #endif

--- a/loader/stage0/abl/stage0.c
+++ b/loader/stage0/abl/stage0.c
@@ -146,6 +146,9 @@ void stage0_main(
 	evmm_desc->sipi_ap_wkup_addr = (uint64_t)vmm_boot->VMMSipiApWkupAddr;
 	evmm_desc->top_of_mem = tom;
 	evmm_desc->tsc_per_ms = 0; //The TSC frequency will be set in Stage1
+#ifdef MODULE_TEMPLATE_TEE
+       evmm_desc->x64_cr3 = asm_get_cr3();
+#endif
 
 	evmm_desc->stage1_file.loadtime_addr = packed_file[STAGE1_BIN_INDEX].load_addr;
 	evmm_desc->stage1_file.loadtime_size = packed_file[STAGE1_BIN_INDEX].size;
@@ -158,6 +161,11 @@ void stage0_main(
 	evmm_desc->evmm_file.runtime_total_size = ((uint64_t)(vmm_boot->VMMMemSize)) << 10;
 
 	fill_g0gcpu0(&evmm_desc->guest0_gcpu0_state, &and_boot->CpuState);
+
+#ifdef MODULE_TRUSTY_TEE
+	/* For trusty, tos.img will be relocated by osloader */
+	evmm_desc->trusty_tee_desc.dev_sec_info = dev_sec_info;
+#endif
 
 #if defined (MODULE_TRUSTY_GUEST)
 	/* tos.img will be relocated by osloader */

--- a/loader/stage0/abl_cl/stage0.c
+++ b/loader/stage0/abl_cl/stage0.c
@@ -112,6 +112,7 @@ static boolean_t fill_device_sec_info(device_sec_info_v0_t *dev_sec_info, uint64
 
 	/* clear original seed */
 	memset(svnseed, 0, sizeof(abl_svnseed_t));
+	barrier();
 
 	if (rpmb_key) {
 		/* RPMB key provisioned by ABL */
@@ -120,6 +121,7 @@ static boolean_t fill_device_sec_info(device_sec_info_v0_t *dev_sec_info, uint64
 
 		/* clear original rpmb key */
 		memset(rpmb_key, 0, ABL_RPMB_KEY_LEN);
+		barrier();
 	} else {
 		/* RPMB key is not provisioned, set a pre-defined key */
 		memset(dev_sec_info->rpmb_key, 0x00, sizeof(dev_sec_info->rpmb_key));

--- a/loader/stage0/abl_osloader/stage0.c
+++ b/loader/stage0/abl_osloader/stage0.c
@@ -26,6 +26,7 @@ void cleanup_sensetive_data(uint64_t tos_startup_info)
 {
 	tos_startup_info_t *p_startup_info = (tos_startup_info_t *)tos_startup_info;
 	memset(p_startup_info->seed_list, 0, sizeof(p_startup_info->seed_list));
+	barrier();
 }
 
 /* Function: stage0_main

--- a/loader/stage0/efi/stage0.c
+++ b/loader/stage0/efi/stage0.c
@@ -26,6 +26,7 @@ void cleanup_sensetive_data(uint64_t tos_startup_info)
 {
 	tos_startup_info_t *p_startup_info = (tos_startup_info_t *)tos_startup_info;
 	memset(p_startup_info->seed_list, 0, sizeof(p_startup_info->seed_list));
+	barrier();
 }
 
 /* Function: stage0_main

--- a/loader/stage0/sbl/seed_list_parse.c
+++ b/loader/stage0/sbl/seed_list_parse.c
@@ -38,6 +38,7 @@ static boolean_t fill_dseed(device_sec_info_v0_t *dev_sec_info, seed_entry_t *en
 
 	/* erase original seed in seed entry */
 	memset(entry->seed, 0, sizeof(seed_info_t));
+	barrier();
 
 	return TRUE;
 }

--- a/loader/stage0/stage0_lib/stage0_lib.c
+++ b/loader/stage0/stage0_lib/stage0_lib.c
@@ -184,6 +184,17 @@ boolean_t file_parse(evmm_desc_t *evmm_desc, uint64_t base, uint32_t offset, uin
 	}
 #endif
 
+#if defined (MODULE_TRUSTY_TEE) && defined (PACK_LK)
+	if (file_hdr->file_size[LK_BIN_INDEX]) {
+		evmm_desc->trusty_tee_desc.tee_file.loadtime_addr = evmm_desc->evmm_file.loadtime_addr +
+			evmm_desc->evmm_file.loadtime_size;
+		evmm_desc->trusty_tee_desc.tee_file.loadtime_size = file_hdr->file_size[LK_BIN_INDEX];
+	} else {
+		print_panic("lk file size is zero\n");
+		return FALSE;
+	}
+#endif
+
 #if defined (MODULE_OPTEE_GUEST) && defined (PACK_OPTEE)
     if (file_hdr->file_size[OPTEE_BIN_INDEX]) {
 		evmm_desc->optee_desc.optee_file.loadtime_addr = evmm_desc->evmm_file.loadtime_addr +

--- a/packer/evmm_packer.c
+++ b/packer/evmm_packer.c
@@ -16,7 +16,7 @@
 #include "file_pack.h"
 #include "vmm_base.h"
 
-#if defined (MODULE_TRUSTY_GUEST) && defined (PACK_LK)
+#if (defined (MODULE_TRUSTY_GUEST) || defined (MODULE_TRUSTY_TEE)) && defined (PACK_LK)
 #define EVMM_PKG_BIN_NAME    "evmm_lk_pkg.bin"
 #elif defined (MODULE_OPTEE_GUEST) && defined (PACK_OPTEE)
 #define EVMM_PKG_BIN_NAME    "evmm_optee_pkg.bin"
@@ -32,7 +32,7 @@ static char* file_list[] = {
 	"stage0.bin",
 	"stage1.bin",
 	"evmm.elf",
-#if defined (MODULE_TRUSTY_GUEST) && defined (PACK_LK)
+#if (defined (MODULE_TRUSTY_GUEST) || defined (MODULE_TRUSTY_TEE)) && defined (PACK_LK)
 	"lk.elf",
 #endif
 

--- a/product/celadon_64.cfg
+++ b/product/celadon_64.cfg
@@ -1,0 +1,28 @@
+EVMM_CMPL_FLAGS :=
+EVMM_CMPL_FLAGS += -DLOG_LEVEL=0
+
+include $(PROJS)/product/board/cel_nuc.cfg
+
+include $(PROJS)/product/feature/trusty.cfg
+include $(PROJS)/product/feature/isolation.cfg
+include $(PROJS)/product/feature/security.cfg
+include $(PROJS)/product/feature/suspend.cfg
+
+export LOADER_STAGE0_SUB = efi
+
+EVMM_CMPL_FLAGS += \
+ -DMODULE_MSR_MONITOR \
+ -DMODULE_TSC \
+ -DMODULE_VMEXIT_INIT\
+ -DPACK_LK \
+ -DMODULE_ACPI \
+ -DMODULE_VTD \
+ -DDMAR_MAX_ENGINE=4 \
+ -DSKIP_DMAR_GPU
+
+EVMM_CMPL_FLAGS += \
+ -DAP_START_IN_HLT
+
+EVMM_CMPL_FLAGS += \
+ -DEVMM_PKG_BIN_SIZE=0x600000
+

--- a/product/celadon_apl.cfg
+++ b/product/celadon_apl.cfg
@@ -1,0 +1,28 @@
+EVMM_CMPL_FLAGS :=
+EVMM_CMPL_FLAGS += -DLOG_LEVEL=0
+
+include $(PROJS)/product/board/cel_nuc.cfg
+
+include $(PROJS)/product/feature/trusty.cfg
+include $(PROJS)/product/feature/isolation.cfg
+include $(PROJS)/product/feature/security.cfg
+include $(PROJS)/product/feature/suspend.cfg
+
+export LOADER_STAGE0_SUB = efi
+
+EVMM_CMPL_FLAGS += \
+ -DMODULE_MSR_MONITOR \
+ -DMODULE_TSC \
+ -DMODULE_VMEXIT_INIT\
+ -DPACK_LK \
+ -DMODULE_ACPI \
+ -DMODULE_VTD \
+ -DDMAR_MAX_ENGINE=4 \
+ -DSKIP_DMAR_GPU
+
+EVMM_CMPL_FLAGS += \
+ -DAP_START_IN_HLT
+
+EVMM_CMPL_FLAGS += \
+ -DEVMM_PKG_BIN_SIZE=0x600000
+

--- a/product/celadon_clk.cfg
+++ b/product/celadon_clk.cfg
@@ -1,0 +1,28 @@
+EVMM_CMPL_FLAGS :=
+EVMM_CMPL_FLAGS += -DLOG_LEVEL=0
+
+include $(PROJS)/product/board/cel_clk.cfg
+
+include $(PROJS)/product/feature/trusty.cfg
+include $(PROJS)/product/feature/isolation.cfg
+include $(PROJS)/product/feature/security.cfg
+include $(PROJS)/product/feature/suspend.cfg
+
+export LOADER_STAGE0_SUB = efi
+
+EVMM_CMPL_FLAGS += \
+ -DMODULE_MSR_MONITOR \
+ -DMODULE_TSC \
+ -DMODULE_VMEXIT_INIT\
+ -DPACK_LK \
+ -DMODULE_ACPI \
+ -DMODULE_VTD \
+ -DDMAR_MAX_ENGINE=4 \
+ -DSKIP_DMAR_GPU
+
+EVMM_CMPL_FLAGS += \
+ -DAP_START_IN_HLT
+
+EVMM_CMPL_FLAGS += \
+ -DEVMM_PKG_BIN_SIZE=0x600000
+

--- a/product/celadon_kbl.cfg
+++ b/product/celadon_kbl.cfg
@@ -1,0 +1,27 @@
+EVMM_CMPL_FLAGS :=
+EVMM_CMPL_FLAGS += -DLOG_LEVEL=0
+
+include $(PROJS)/product/board/cel_nuc.cfg
+
+include $(PROJS)/product/feature/trusty.cfg
+include $(PROJS)/product/feature/isolation.cfg
+include $(PROJS)/product/feature/security.cfg
+include $(PROJS)/product/feature/suspend.cfg
+
+export LOADER_STAGE0_SUB = efi
+
+EVMM_CMPL_FLAGS += \
+ -DMODULE_MSR_MONITOR \
+ -DMODULE_TSC \
+ -DMODULE_VMEXIT_INIT\
+ -DPACK_LK \
+ -DMODULE_ACPI \
+ -DMODULE_VTD \
+ -DDMAR_MAX_ENGINE=4
+
+EVMM_CMPL_FLAGS += \
+ -DAP_START_IN_HLT
+
+EVMM_CMPL_FLAGS += \
+ -DEVMM_PKG_BIN_SIZE=0x600000
+

--- a/product/feature/trusty_tee.cfg
+++ b/product/feature/trusty_tee.cfg
@@ -1,0 +1,17 @@
+#EPT_POLICY is a 32-bits field:
+# [   0]  --  1 means enable UG/EPT for real mode only, 0 means always enable UG/EPT
+# [30:1]  --  reserved
+# [  31]  --  1 means enable EPT, 0 means disable EPT
+EVMM_CMPL_FLAGS += \
+ -DEPT_POLICY=0x80000000
+
+EVMM_CMPL_FLAGS += \
+ -DMODULE_VMCALL \
+ -DMODULE_TEMPLATE_TEE \
+ -DMODULE_TRUSTY_TEE
+
+
+ifneq ($(TARGET_BUILD_VARIANT),user)
+EVMM_CMPL_FLAGS += \
+ -DMODULE_DEADLOOP
+endif

--- a/readme.txt
+++ b/readme.txt
@@ -143,6 +143,12 @@ Config files
 	- MODULE_TEMPLATE_TEE
 		Description: Provide Tee guest framework
 
+	- MODULE_TRUSTY_TEE
+		Description: Enable Trusty based on template tee framework
+		Dependency:
+			MODULE_TEMPLATE_TEE
+			others refer to MODULE_TRUSTY_GUEST
+
 	- MODULE_TRUSTY_GUEST
 		Description: Enable Trusty.
 		Dependency:

--- a/readme.txt
+++ b/readme.txt
@@ -244,4 +244,7 @@ Config files
 			- NPK_PCI_DEV
 			- NPK_PCI_FUN
 
+	 - MODULE_SECURITY_INFO
+		Description: Set device secure information and provide derive key function
+
 End of file

--- a/vmm/guest/gcpu_state.c
+++ b/vmm/guest/gcpu_state.c
@@ -296,10 +296,14 @@ static void g0gcpu_set_guest_state(guest_cpu_handle_t gcpu, UNUSED void *pv)
 	VMM_ASSERT_EX(g0gcpu0_state, "g0gcpu0_state is NULL\n");
 
 	if (gcpu->guest->id == 0) {
-		if (gcpu->id == 0)
+		if (gcpu->id == 0) {
 			gcpu_set_init_state(gcpu, g0gcpu0_state);
-		else
+		} else {
 			gcpu_set_reset_state(gcpu);
+#ifdef AP_START_IN_HLT
+			vmcs_write(gcpu->vmcs, VMCS_GUEST_ACTIVITY_STATE, ACTIVITY_STATE_HLT);
+#endif
+		}
 	}
 }
 

--- a/vmm/include/modules/security_info.h
+++ b/vmm/include/modules/security_info.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015-2019 Intel Corporation.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef _SECURITY_INFO_H
+#define _SECURITY_INFO_H
+
+#ifndef MODULE_SECURITY_INFO
+#error "MODULE_SECURITY_INFO is not defined"
+#endif
+
+#include "vmm_base.h"
+
+#define INTERNAL NULL
+
+/* When dest is INTERNAL, an internal memory will be allocated to hold the info;
+ * when src is INTERNAL, the info stored in the internal memory will be moved to dest,
+ * and the internal memory will be freed */
+uint32_t mov_sec_info(void *dest, void *src);
+
+#endif

--- a/vmm/include/modules/template_tee.h
+++ b/vmm/include/modules/template_tee.h
@@ -57,6 +57,21 @@ typedef struct {
 	uint32_t tee_ap_status; // WAIT-FOR-SIPI, HLT, 32 bit, 64 bit
 } tee_config_t;
 
+#define fill_smc_param_to_tee(cfg, array)				  \
+	{ 								  \
+		uint32_t i;						  \
+		cfg.smc_param_to_tee_nr = sizeof(array)/sizeof(array[0]); \
+		for (i=0; i<cfg.smc_param_to_tee_nr; i++)		  \
+			cfg.smc_param_to_tee[i] = array[i];		  \
+	}
+
+#define fill_smc_param_from_tee(cfg, array)				  \
+	{								  \
+		uint32_t i;						  \
+		cfg.smc_param_to_ree_nr = sizeof(array)/sizeof(array[0]); \
+		for (i=0; i<cfg.smc_param_to_ree_nr; i++)		  \
+			cfg.smc_param_to_ree[i] = array[i];		  \
+	}
 
 guest_handle_t create_tee(tee_config_t* cfg);
 /* If tee_rt_addr or tee_rt_size equals to 0, values set in create_tee() will be used */

--- a/vmm/include/modules/trusty_tee.h
+++ b/vmm/include/modules/trusty_tee.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2015-2019 Intel Corporation.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef _TRUSTY_TEE_H
+#define _TRUSTY_TEE_H
+
+#ifndef MODULE_TRUSTY_TEE
+#error "MODULE_TRUSTY_TEE is not defined"
+#endif
+
+#include "evmm_desc.h"
+
+void init_trusty_tee(evmm_desc_t *evmm_desc);
+void trusty_register_deadloop_handler(evmm_desc_t *evmm_desc);
+
+#endif

--- a/vmm/main.c
+++ b/vmm/main.c
@@ -50,6 +50,14 @@
 #include "modules/lapic_id.h"
 #endif
 
+#ifdef MODULE_TEMPLATE_TEE
+#include "modules/template_tee.h"
+#endif
+
+#ifdef MODULE_TRUSTY_TEE
+#include "modules/trusty_tee.h"
+#endif
+
 #ifdef MODULE_TRUSTY_GUEST
 #include "modules/trusty_guest.h"
 #endif
@@ -158,10 +166,6 @@
 #include "modules/block_npk.h"
 #endif
 
-#ifdef MODULE_TEMPLATE_TEE
-#include "modules/template_tee.h"
-#endif
-
 typedef struct {
 	uint64_t	cpuid;
 	uint64_t	evmm_desc;
@@ -222,7 +226,7 @@ void vmm_main_continue(vmm_input_params_t *vmm_input_params)
 
 	/* stage 1: setup host */
 	if (cpuid == 0) {
-#ifdef MODULE_TRUSTY_GUEST
+#if defined(MODULE_TRUSTY_GUEST) || defined(MODULE_TRUSTY_TEE)
 		trusty_register_deadloop_handler(evmm_desc);
 #endif
 
@@ -485,6 +489,10 @@ void vmm_main_continue(vmm_input_params_t *vmm_input_params)
 
 		/* Create guest with RWX(0x7) attribute */
 		create_guest(host_cpu_num, 0x7);
+
+#ifdef MODULE_TRUSTY_TEE
+		init_trusty_tee(evmm_desc);
+#endif
 
 #ifdef MODULE_TRUSTY_GUEST
 		/* Dependency:

--- a/vmm/modules/nested_vt/emulate_vmentry.c
+++ b/vmm/modules/nested_vt/emulate_vmentry.c
@@ -16,7 +16,7 @@ static void copy_from_gvmcs(guest_cpu_handle_t gcpu, uint64_t *gvmcs, vmcs_field
 	vmcs_write(gcpu->vmcs, vmcs_field, gvmcs[vmcs_field]);
 }
 
-static void handle_io_bitmap_a(guest_cpu_handle_t gcpu, uint64_t *gvmcs, vmcs_field_t vmcs_field UNUSED UNUSED)
+static void handle_io_bitmap_a(guest_cpu_handle_t gcpu, uint64_t *gvmcs, vmcs_field_t vmcs_field UNUSED)
 {
 	/* TODO: merge with hvmcs */
 	vmcs_write(gcpu->vmcs, VMCS_IO_BITMAP_A, gvmcs[VMCS_IO_BITMAP_A]);

--- a/vmm/modules/nested_vt/emulate_vmexit.c
+++ b/vmm/modules/nested_vt/emulate_vmexit.c
@@ -8,153 +8,456 @@
 
 #include "gcpu.h"
 #include "vmcs.h"
+#include "vmexit_cr_access.h"
 #include "nested_vt_internal.h"
 
-#define VMEXIT_COPY_FROM_HVMCS 0
-#define VMEXIT_NO_CHANGE       1
-#define VMEXIT_OTHERS          2
+static void copy_from_hvmcs(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id)
+{
+	vmcs_write(gcpu->vmcs, field_id, data->hvmcs[field_id]);
+}
 
+static void handle_entry_msr_load_count(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	/* TODO: merge with hvmcs */
+	vmcs_write(gcpu->vmcs, VMCS_ENTRY_MSR_LOAD_COUNT, data->gvmcs[VMCS_EXIT_MSR_LOAD_COUNT]);
+}
+
+static void handle_entry_msr_load_addr(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	/* TODO: merge with hvmcs */
+	vmcs_write(gcpu->vmcs, VMCS_ENTRY_MSR_LOAD_ADDR, data->gvmcs[VMCS_EXIT_MSR_LOAD_ADDR]);
+}
+
+static void handle_guest_dbgctl(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* Clear to 0 according to SDM: Vol3, Chapter 27.5.1 Loading Host Control Registers, Debug Registers, MSRs */
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_DBGCTL, 0);
+}
+
+static void handle_guest_interruptibility(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_INTERRUPTIBILITY, 0);
+}
+
+static void handle_guest_interrupt_status(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_INTERRUPT_STATUS, 0);
+}
+
+static void handle_guest_pend_dbg_exception(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* Clear to 0 according to SDM: Vol3, Chapter 27.5.5 Updating Non-Register State */
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_PEND_DBG_EXCEPTION, 0);
+}
+
+static void handle_guest_pat(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_PAT, data->gvmcs[VMCS_HOST_PAT]);
+}
+
+static void handle_guest_efer(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_EFER, data->gvmcs[VMCS_HOST_EFER]);
+}
+
+static void handle_guest_perf_g_ctrl(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_PERF_G_CTRL, data->gvmcs[VMCS_HOST_PERF_G_CTRL]);
+}
+
+static void handle_guest_pdptr0(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* TODO: handle PAE paging if L1 use PAE paging */
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_PDPTR0, 0);
+}
+
+static void handle_guest_pdptr1(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* TODO: handle PAE paging if L1 use PAE paging */
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_PDPTR1, 0);
+}
+
+static void handle_guest_pdptr2(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* TODO: handle PAE paging if L1 use PAE paging */
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_PDPTR2, 0);
+}
+
+static void handle_guest_pdptr3(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* TODO: handle PAE paging if L1 use PAE paging */
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_PDPTR3, 0);
+}
+
+static void handle_guest_cr0(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_CR0, data->gvmcs[VMCS_HOST_CR0]);
+}
+
+static void handle_guest_cr3(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_CR3, data->gvmcs[VMCS_HOST_CR3]);
+}
+
+static void handle_guest_cr4(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_CR4, data->gvmcs[VMCS_HOST_CR4]);
+}
+
+static void handle_guest_dr7(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* Set to 0x400 according to SDM: Vol3, Chapter 27.5.1 Loading Host Control Registers, Debug Registers, MSRs */
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_DR7, 0x400);
+}
+
+static void handle_guest_gdtr_base(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_GDTR_BASE, data->gvmcs[VMCS_HOST_GDTR_BASE]);
+}
+
+static void handle_guest_gdtr_limit(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* Set to 0xFFFF according to SDM: Vol3, Chapter 27.5.2 Loading Host Segment and Descriptor-Table Registers */
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_GDTR_LIMIT, 0xFFFF);
+}
+
+static void handle_guest_idtr_base(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_IDTR_BASE, data->gvmcs[VMCS_HOST_IDTR_BASE]);
+}
+
+static void handle_guest_idtr_limit(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_IDTR_LIMIT, 0xFFFF);
+}
+
+static void handle_guest_activity_state(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* Set active state according to SDM: Vol3, Chapter 27.5.5 Updating Non-Register State */
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_ACTIVITY_STATE, ACTIVITY_STATE_ACTIVE);
+}
+
+static void handle_guest_sysenter_cs(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_SYSENTER_CS, data->gvmcs[VMCS_HOST_SYSENTER_CS]);
+}
+
+static void handle_guest_sysenter_esp(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_SYSENTER_ESP, data->gvmcs[VMCS_HOST_SYSENTER_ESP]);
+}
+
+static void handle_guest_sysenter_eip(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_SYSENTER_EIP, data->gvmcs[VMCS_HOST_SYSENTER_EIP]);
+}
+
+static void handle_guest_es_sel(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_ES_SEL, data->gvmcs[VMCS_HOST_ES_SEL]);
+}
+
+static void handle_guest_seg_base(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id)
+{
+	/* Clear to 0 for ES/CS/DS/SS/LDTR according to SDM: Vol3, Chapter 27.5.2 Loading Host Segment and Descriptor-Table Registers */
+	vmcs_write(gcpu->vmcs, field_id, 0);
+}
+
+static void handle_guest_seg_limit(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id)
+{
+	/* Set to 0xFFFFFFFF for ES/CS/DS/SS/FS/GS according to SDM: Vol3, Chapter 27.5.2 Loading Host Segment and Descriptor-Table Registers */
+	vmcs_write(gcpu->vmcs, field_id, 0xFFFFFFFF);
+}
+
+static void handle_guest_es_ar(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* Set segment AR according to SDM: Vol3, Chapter 27.5.2 Loading Host Segment and Descriptor-Table Registers */
+	if (data->gvmcs[VMCS_HOST_ES_SEL]) {
+		vmcs_write(gcpu->vmcs, VMCS_GUEST_ES_AR, 3 | (1 << 4) | (1 << 7) | (1 << 14) | (1 << 15));
+	} else {
+		vmcs_write(gcpu->vmcs, VMCS_GUEST_ES_AR, 1 << 16);
+	}
+}
+
+static void handle_guest_cs_sel(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_CS_SEL, data->gvmcs[VMCS_HOST_CS_SEL]);
+}
+
+static void handle_guest_cs_ar(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* Set segment AR according to SDM: Vol3, Chapter 27.5.2 Loading Host Segment and Descriptor-Table Registers */
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_CS_AR, 0xB | (1 << 7) | ((!(data->gvmcs[VMCS_EXIT_CTRL] >> 9)) << 14) | (1 << 15));
+}
+
+static void handle_guest_ss_sel(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_SS_SEL, data->gvmcs[VMCS_HOST_SS_SEL]);
+}
+
+static void handle_guest_ss_ar(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* Set segment AR according to SDM: Vol3, Chapter 27.5.2 Loading Host Segment and Descriptor-Table Registers */
+	if (data->gvmcs[VMCS_HOST_SS_SEL]) {
+		vmcs_write(gcpu->vmcs, VMCS_GUEST_SS_AR, 3 | (1 << 4) | (1 << 7) | (1 << 14) | (1 << 15));
+	} else {
+		vmcs_write(gcpu->vmcs, VMCS_GUEST_SS_AR, (1 << 14) | (1 << 16));
+	}
+}
+
+static void handle_guest_ds_sel(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_DS_SEL, data->gvmcs[VMCS_HOST_DS_SEL]);
+}
+
+static void handle_guest_ds_ar(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* Set segment AR according to SDM: Vol3, Chapter 27.5.2 Loading Host Segment and Descriptor-Table Registers */
+	if (data->gvmcs[VMCS_HOST_DS_SEL]) {
+		vmcs_write(gcpu->vmcs, VMCS_GUEST_DS_AR, 3 | (1 << 4) | (1 << 7) | (1 << 14) | (1 << 15));
+	} else {
+		vmcs_write(gcpu->vmcs, VMCS_GUEST_DS_AR, 1 << 16);
+	}
+}
+
+static void handle_guest_fs_sel(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_FS_SEL, data->gvmcs[VMCS_HOST_FS_SEL]);
+}
+
+static void handle_guest_fs_base(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_FS_BASE, data->gvmcs[VMCS_HOST_FS_BASE]);
+}
+
+static void handle_guest_fs_ar(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* Set segment AR according to SDM: Vol3, Chapter 27.5.2 Loading Host Segment and Descriptor-Table Registers */
+	if (data->gvmcs[VMCS_HOST_FS_SEL]) {
+		vmcs_write(gcpu->vmcs, VMCS_GUEST_FS_AR, 3 | (1 << 4) | (1 << 7) | (1 << 14) | (1 << 15));
+	} else {
+		vmcs_write(gcpu->vmcs, VMCS_GUEST_FS_AR, 1 << 16);
+	}
+}
+
+static void handle_guest_gs_sel(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_GS_SEL, data->gvmcs[VMCS_HOST_GS_SEL]);
+}
+
+static void handle_guest_gs_base(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_GS_BASE, data->gvmcs[VMCS_HOST_GS_BASE]);
+}
+
+static void handle_guest_gs_ar(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* Set segment AR according to SDM: Vol3, Chapter 27.5.2 Loading Host Segment and Descriptor-Table Registers */
+	if (data->gvmcs[VMCS_HOST_GS_SEL]) {
+		vmcs_write(gcpu->vmcs, VMCS_GUEST_GS_AR, 3 | (1 << 4) | (1 << 7) | (1 << 14) | (1 << 15));
+	} else {
+		vmcs_write(gcpu->vmcs, VMCS_GUEST_GS_AR, 1 << 16);
+	}
+}
+
+static void handle_guest_ldtr_sel(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* Set LDTR according to SDM: Vol3, Chapter 27.5.2 Loading Host Segment and Descriptor-Table Registers */
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_LDTR_SEL, 0);
+}
+
+static void handle_guest_ldtr_limit(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* Set LDTR according to SDM: Vol3, Chapter 27.5.2 Loading Host Segment and Descriptor-Table Registers */
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_LDTR_LIMIT, 0);
+}
+
+static void handle_guest_ldtr_ar(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* Set LDTR according to SDM: Vol3, Chapter 27.5.2 Loading Host Segment and Descriptor-Table Registers */
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_LDTR_AR, 1 << 16);
+}
+
+static void handle_guest_tr_sel(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_TR_SEL, data->gvmcs[VMCS_HOST_TR_SEL]);
+}
+
+static void handle_guest_tr_base(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_TR_BASE, data->gvmcs[VMCS_HOST_TR_BASE]);
+}
+
+static void handle_guest_tr_limit(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* Set to 0x67 according to SDM: Vol3, Chapter 27.5.2 Loading Host Segment and Descriptor-Table Registers */
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_TR_LIMIT, 0x67);
+}
+
+static void handle_guest_tr_ar(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* Set segment AR according to SDM: Vol3, Chapter 27.5.2 Loading Host Segment and Descriptor-Table Registers */
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_CS_AR, 0xB | (1 << 7));
+}
+
+static void handle_guest_rsp(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_RSP, data->gvmcs[VMCS_HOST_RSP]);
+}
+
+static void handle_guest_rip(guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id UNUSED)
+{
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_RIP, data->gvmcs[VMCS_HOST_RIP]);
+}
+
+static void handle_guest_rflags(guest_cpu_handle_t gcpu, nestedvt_data_t *data UNUSED, vmcs_field_t field_id UNUSED)
+{
+	/* Clear RFLAGS except bit 1 according to SDM: Vol3, Chapter 27.5.3 Loading Host RIP RSP and RFLAGS */
+	vmcs_write(gcpu->vmcs, VMCS_GUEST_RFLAGS, 1 << 1);
+}
+
+typedef void (*vmexit_vmcs_handler_t) (guest_cpu_handle_t gcpu, nestedvt_data_t *data, vmcs_field_t field_id);
 typedef struct {
-	uint32_t handle_type:       2;
-	uint32_t copy_to_gvmcs:     1;
-	uint32_t rsvd:             29;
+	vmexit_vmcs_handler_t handler;
+	boolean_t copy_to_gvmcs;
+	uint32_t pad;
 } vmexit_vmcs_handle_t;
 
 static vmexit_vmcs_handle_t vmexit_vmcs_handle_array[] = {
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_VPID
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_IO_BITMAP_A
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_IO_BITMAP_B
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_MSR_BITMAP
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_TSC_OFFSET
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_VIRTUAL_APIC_ADDR
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_APIC_ACCESS_ADDR
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_POST_INTR_NOTI_VECTOR
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_POST_INTR_DESC_ADDR
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_EOI_EXIT_BITMAP0
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_EOI_EXIT_BITMAP1
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_EOI_EXIT_BITMAP2
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_EOI_EXIT_BITMAP3
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_TPR_THRESHOLD
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_EPTP_ADDRESS
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_XSS_EXIT_BITMAP
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_PIN_CTRL
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_PROC_CTRL1
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_PROC_CTRL2
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_EXIT_CTRL
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_CR0_MASK
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_CR4_MASK
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_CR0_SHADOW
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_CR4_SHADOW
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_CR3_TARGET0
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_CR3_TARGET1
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_CR3_TARGET2
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_CR3_TARGET3
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_LINK_PTR
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_CR0
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_CR3
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_CR4
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_ES_SEL
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_CS_SEL
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_SS_SEL
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_DS_SEL
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_FS_SEL
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_FS_BASE
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_GS_SEL
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_GS_BASE
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_TR_SEL
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_TR_BASE
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_GDTR_BASE
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_IDTR_BASE
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_RSP
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_RIP
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_PAT
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_EFER
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_PERF_G_CTRL
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_EXIT_MSR_STORE_COUNT
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_EXIT_MSR_STORE_ADDR
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_EXIT_MSR_LOAD_COUNT
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_EXIT_MSR_LOAD_ADDR
-	{ VMEXIT_OTHERS,          FALSE, 0 }, //VMCS_ENTRY_MSR_LOAD_COUNT
-	{ VMEXIT_OTHERS,          FALSE, 0 }, //VMCS_ENTRY_MSR_LOAD_ADDR
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_EXCEPTION_BITMAP
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_SYSENTER_CS
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_SYSENTER_ESP
-	{ VMEXIT_NO_CHANGE,       FALSE, 0 }, //VMCS_HOST_SYSENTER_EIP
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_CR3_TARGET_COUNT
-	{ VMEXIT_OTHERS,          FALSE, 0 }, //VMCS_ENTRY_INTR_INFO
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_DBGCTL
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_INTERRUPTIBILITY
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_INTERRUPT_STATUS
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_PEND_DBG_EXCEPTION
-	{ VMEXIT_OTHERS,          FALSE, 0 }, //VMCS_ENTRY_ERR_CODE
-	{ VMEXIT_COPY_FROM_HVMCS, FALSE, 0 }, //VMCS_ENTRY_CTRL
-	{ VMEXIT_OTHERS,          FALSE, 0 }, //VMCS_ENTRY_INSTR_LEN
-	{ VMEXIT_COPY_FROM_HVMCS, TRUE,  0 }, //VMCS_PREEMPTION_TIMER
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_PAT
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_EFER
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_PERF_G_CTRL
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_PDPTR0
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_PDPTR1
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_PDPTR2
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_PDPTR3
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_CR0
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_CR3
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_CR4
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_DR7
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_GDTR_BASE
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_GDTR_LIMIT
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_IDTR_BASE
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_IDTR_LIMIT
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_ACTIVITY_STATE
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_SYSENTER_CS
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_SYSENTER_ESP
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_SYSENTER_EIP
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_ES_SEL
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_ES_BASE
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_ES_LIMIT
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_ES_AR
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_CS_SEL
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_CS_BASE
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_CS_LIMIT
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_CS_AR
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_SS_SEL
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_SS_BASE
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_SS_LIMIT
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_SS_AR
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_DS_SEL
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_DS_BASE
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_DS_LIMIT
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_DS_AR
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_FS_SEL
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_FS_BASE
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_FS_LIMIT
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_FS_AR
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_GS_SEL
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_GS_BASE
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_GS_LIMIT
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_GS_AR
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_LDTR_SEL
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_LDTR_BASE
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_LDTR_LIMIT
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_LDTR_AR
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_TR_SEL
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_TR_BASE
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_TR_LIMIT
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_TR_AR
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_RSP
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_RIP
-	{ VMEXIT_OTHERS,          TRUE,  0 }, //VMCS_GUEST_RFLAGS
-	{ VMEXIT_NO_CHANGE,       TRUE,  0 }, //VMCS_GUEST_PHY_ADDR
-	{ VMEXIT_NO_CHANGE,       TRUE,  0 }, //VMCS_GUEST_LINEAR_ADDR
-	{ VMEXIT_NO_CHANGE,       TRUE,  0 }, //VMCS_INSTR_ERROR
-	{ VMEXIT_NO_CHANGE,       TRUE,  0 }, //VMCS_EXIT_REASON
-	{ VMEXIT_NO_CHANGE,       TRUE,  0 }, //VMCS_EXIT_INT_INFO
-	{ VMEXIT_NO_CHANGE,       TRUE,  0 }, //VMCS_EXIT_INT_ERR_CODE
-	{ VMEXIT_NO_CHANGE,       TRUE,  0 }, //VMCS_IDT_VECTOR_INFO
-	{ VMEXIT_NO_CHANGE,       TRUE,  0 }, //VMCS_IDT_VECTOR_ERR_CODE
-	{ VMEXIT_NO_CHANGE,       TRUE,  0 }, //VMCS_EXIT_INSTR_LEN
-	{ VMEXIT_NO_CHANGE,       TRUE,  0 }, //VMCS_EXIT_INSTR_INFO
-	{ VMEXIT_NO_CHANGE,       TRUE,  0 }, //VMCS_EXIT_QUAL
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_VPID
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_IO_BITMAP_A
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_IO_BITMAP_B
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_MSR_BITMAP
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_TSC_OFFSET
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_VIRTUAL_APIC_ADDR
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_APIC_ACCESS_ADDR
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_POST_INTR_NOTI_VECTOR
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_POST_INTR_DESC_ADDR
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_EOI_EXIT_BITMAP0
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_EOI_EXIT_BITMAP1
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_EOI_EXIT_BITMAP2
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_EOI_EXIT_BITMAP3
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_TPR_THRESHOLD
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_EPTP_ADDRESS
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_XSS_EXIT_BITMAP
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_PIN_CTRL
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_PROC_CTRL1
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_PROC_CTRL2
+	{ NULL,                              FALSE, 0 }, //VMCS_EXIT_CTRL
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_CR0_MASK
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_CR4_MASK
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_CR0_SHADOW
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_CR4_SHADOW
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_CR3_TARGET0
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_CR3_TARGET1
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_CR3_TARGET2
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_CR3_TARGET3
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_LINK_PTR
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_CR0
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_CR3
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_CR4
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_ES_SEL
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_CS_SEL
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_SS_SEL
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_DS_SEL
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_FS_SEL
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_FS_BASE
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_GS_SEL
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_GS_BASE
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_TR_SEL
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_TR_BASE
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_GDTR_BASE
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_IDTR_BASE
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_RSP
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_RIP
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_PAT
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_EFER
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_PERF_G_CTRL
+	{ NULL,                              FALSE, 0 }, //VMCS_EXIT_MSR_STORE_COUNT
+	{ NULL,                              FALSE, 0 }, //VMCS_EXIT_MSR_STORE_ADDR
+	{ NULL,                              FALSE, 0 }, //VMCS_EXIT_MSR_LOAD_COUNT
+	{ NULL,                              FALSE, 0 }, //VMCS_EXIT_MSR_LOAD_ADDR
+	{ handle_entry_msr_load_count,       FALSE, 0 }, //VMCS_ENTRY_MSR_LOAD_COUNT
+	{ handle_entry_msr_load_addr,        FALSE, 0 }, //VMCS_ENTRY_MSR_LOAD_ADDR
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_EXCEPTION_BITMAP
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_SYSENTER_CS
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_SYSENTER_ESP
+	{ NULL,                              FALSE, 0 }, //VMCS_HOST_SYSENTER_EIP
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_CR3_TARGET_COUNT
+	{ NULL,                              FALSE, 0 }, //VMCS_ENTRY_INTR_INFO
+	{ handle_guest_dbgctl,                TRUE, 0 }, //VMCS_GUEST_DBGCTL
+	{ handle_guest_interruptibility,      TRUE, 0 }, //VMCS_GUEST_INTERRUPTIBILITY
+	{ handle_guest_interrupt_status,      TRUE, 0 }, //VMCS_GUEST_INTERRUPT_STATUS
+	{ handle_guest_pend_dbg_exception,    TRUE, 0 }, //VMCS_GUEST_PEND_DBG_EXCEPTION
+	{ NULL,                              FALSE, 0 }, //VMCS_ENTRY_ERR_CODE
+	{ copy_from_hvmcs,                   FALSE, 0 }, //VMCS_ENTRY_CTRL
+	{ NULL,                              FALSE, 0 }, //VMCS_ENTRY_INSTR_LEN
+	{ copy_from_hvmcs,                    TRUE, 0 }, //VMCS_PREEMPTION_TIMER
+	{ handle_guest_pat,                   TRUE, 0 }, //VMCS_GUEST_PAT
+	{ handle_guest_efer,                  TRUE, 0 }, //VMCS_GUEST_EFER
+	{ handle_guest_perf_g_ctrl,           TRUE, 0 }, //VMCS_GUEST_PERF_G_CTRL
+	{ handle_guest_pdptr0,                TRUE, 0 }, //VMCS_GUEST_PDPTR0
+	{ handle_guest_pdptr1,                TRUE, 0 }, //VMCS_GUEST_PDPTR1
+	{ handle_guest_pdptr2,                TRUE, 0 }, //VMCS_GUEST_PDPTR2
+	{ handle_guest_pdptr3,                TRUE, 0 }, //VMCS_GUEST_PDPTR3
+	{ handle_guest_cr0,                   TRUE, 0 }, //VMCS_GUEST_CR0
+	{ handle_guest_cr3,                   TRUE, 0 }, //VMCS_GUEST_CR3
+	{ handle_guest_cr4,                   TRUE, 0 }, //VMCS_GUEST_CR4
+	{ handle_guest_dr7,                   TRUE, 0 }, //VMCS_GUEST_DR7
+	{ handle_guest_gdtr_base,             TRUE, 0 }, //VMCS_GUEST_GDTR_BASE
+	{ handle_guest_gdtr_limit,            TRUE, 0 }, //VMCS_GUEST_GDTR_LIMIT
+	{ handle_guest_idtr_base,             TRUE, 0 }, //VMCS_GUEST_IDTR_BASE
+	{ handle_guest_idtr_limit,            TRUE, 0 }, //VMCS_GUEST_IDTR_LIMIT
+	{ handle_guest_activity_state,        TRUE, 0 }, //VMCS_GUEST_ACTIVITY_STATE
+	{ handle_guest_sysenter_cs,           TRUE, 0 }, //VMCS_GUEST_SYSENTER_CS
+	{ handle_guest_sysenter_esp,          TRUE, 0 }, //VMCS_GUEST_SYSENTER_ESP
+	{ handle_guest_sysenter_eip,          TRUE, 0 }, //VMCS_GUEST_SYSENTER_EIP
+	{ handle_guest_es_sel,                TRUE, 0 }, //VMCS_GUEST_ES_SEL
+	{ handle_guest_seg_base,              TRUE, 0 }, //VMCS_GUEST_ES_BASE
+	{ handle_guest_seg_limit,             TRUE, 0 }, //VMCS_GUEST_ES_LIMIT
+	{ handle_guest_es_ar,                 TRUE, 0 }, //VMCS_GUEST_ES_AR
+	{ handle_guest_cs_sel,                TRUE, 0 }, //VMCS_GUEST_CS_SEL
+	{ handle_guest_seg_base,              TRUE, 0 }, //VMCS_GUEST_CS_BASE
+	{ handle_guest_seg_limit,             TRUE, 0 }, //VMCS_GUEST_CS_LIMIT
+	{ handle_guest_cs_ar,                 TRUE, 0 }, //VMCS_GUEST_CS_AR
+	{ handle_guest_ss_sel,                TRUE, 0 }, //VMCS_GUEST_SS_SEL
+	{ handle_guest_seg_base,              TRUE, 0 }, //VMCS_GUEST_SS_BASE
+	{ handle_guest_seg_limit,             TRUE, 0 }, //VMCS_GUEST_SS_LIMIT
+	{ handle_guest_ss_ar,                 TRUE, 0 }, //VMCS_GUEST_SS_AR
+	{ handle_guest_ds_sel,                TRUE, 0 }, //VMCS_GUEST_DS_SEL
+	{ handle_guest_seg_base,              TRUE, 0 }, //VMCS_GUEST_DS_BASE
+	{ handle_guest_seg_limit,             TRUE, 0 }, //VMCS_GUEST_DS_LIMIT
+	{ handle_guest_ds_ar,                 TRUE, 0 }, //VMCS_GUEST_DS_AR
+	{ handle_guest_fs_sel,                TRUE, 0 }, //VMCS_GUEST_FS_SEL
+	{ handle_guest_fs_base,               TRUE, 0 }, //VMCS_GUEST_FS_BASE
+	{ handle_guest_seg_limit,             TRUE, 0 }, //VMCS_GUEST_FS_LIMIT
+	{ handle_guest_fs_ar,                 TRUE, 0 }, //VMCS_GUEST_FS_AR
+	{ handle_guest_gs_sel,                TRUE, 0 }, //VMCS_GUEST_GS_SEL
+	{ handle_guest_gs_base,               TRUE, 0 }, //VMCS_GUEST_GS_BASE
+	{ handle_guest_seg_limit,             TRUE, 0 }, //VMCS_GUEST_GS_LIMIT
+	{ handle_guest_gs_ar,                 TRUE, 0 }, //VMCS_GUEST_GS_AR
+	{ handle_guest_ldtr_sel,              TRUE, 0 }, //VMCS_GUEST_LDTR_SEL
+	{ handle_guest_seg_base,              TRUE, 0 }, //VMCS_GUEST_LDTR_BASE
+	{ handle_guest_ldtr_limit,            TRUE, 0 }, //VMCS_GUEST_LDTR_LIMIT
+	{ handle_guest_ldtr_ar,               TRUE, 0 }, //VMCS_GUEST_LDTR_AR
+	{ handle_guest_tr_sel,                TRUE, 0 }, //VMCS_GUEST_TR_SEL
+	{ handle_guest_tr_base,               TRUE, 0 }, //VMCS_GUEST_TR_BASE
+	{ handle_guest_tr_limit,              TRUE, 0 }, //VMCS_GUEST_TR_LIMIT
+	{ handle_guest_tr_ar,                 TRUE, 0 }, //VMCS_GUEST_TR_AR
+	{ handle_guest_rsp,                   TRUE, 0 }, //VMCS_GUEST_RSP
+	{ handle_guest_rip,                   TRUE, 0 }, //VMCS_GUEST_RIP
+	{ handle_guest_rflags,                TRUE, 0 }, //VMCS_GUEST_RFLAGS
+	{ NULL,                               TRUE, 0 }, //VMCS_GUEST_PHY_ADDR
+	{ NULL,                               TRUE, 0 }, //VMCS_GUEST_LINEAR_ADDR
+	{ NULL,                               TRUE, 0 }, //VMCS_INSTR_ERROR
+	{ NULL,                               TRUE, 0 }, //VMCS_EXIT_REASON
+	{ NULL,                               TRUE, 0 }, //VMCS_EXIT_INT_INFO
+	{ NULL,                               TRUE, 0 }, //VMCS_EXIT_INT_ERR_CODE
+	{ NULL,                               TRUE, 0 }, //VMCS_IDT_VECTOR_INFO
+	{ NULL,                               TRUE, 0 }, //VMCS_IDT_VECTOR_ERR_CODE
+	{ NULL,                               TRUE, 0 }, //VMCS_EXIT_INSTR_LEN
+	{ NULL,                               TRUE, 0 }, //VMCS_EXIT_INSTR_INFO
+	{ NULL,                               TRUE, 0 }, //VMCS_EXIT_QUAL
 };
 
 _Static_assert(sizeof(vmexit_vmcs_handle_array)/sizeof(vmexit_vmcs_handle_t) == VMCS_FIELD_COUNT,
@@ -164,42 +467,31 @@ void emulate_vmexit(guest_cpu_handle_t gcpu)
 {
 	vmcs_obj_t vmcs;
 	nestedvt_data_t *data;
-	uint64_t *gvmcs;
-	uint64_t *hvmcs;
 	uint32_t i;
 
 	vmcs = gcpu->vmcs;
 	data = get_nestedvt_data(gcpu);
-	gvmcs = data->gvmcs;
-	hvmcs = data->hvmcs;
 
 	/* Copy VMCS fields for Layer-1 */
 	for (i = 0; i < VMCS_FIELD_COUNT; i++) {
 		if (vmexit_vmcs_handle_array[i].copy_to_gvmcs) {
-			gvmcs[i] = vmcs_read(vmcs, i);
+			data->gvmcs[i] = vmcs_read(vmcs, i);
 		}
 	}
 
-	/*
-	 * Set VMCS fields according to handle type:
-	 *     1. Copy from Layer-0's VMCS;
-	 *     2. No change;
-	 *     3. Others: will be handled specifically.
-	 */
+	/* Clear GVMCS fields */
+	data->gvmcs[VMCS_ENTRY_INTR_INFO] = 0;
+	data->gvmcs[VMCS_ENTRY_ERR_CODE] = 0;
+	data->gvmcs[VMCS_ENTRY_INSTR_LEN] = 0;
+
+	/* Trigger all VMCS fields handlers */
 	for (i = 0; i < VMCS_FIELD_COUNT; i++) {
-		switch (vmexit_vmcs_handle_array[i].handle_type) {
-		case VMEXIT_COPY_FROM_HVMCS:
-			vmcs_write(vmcs, i, hvmcs[i]);
-			break;
-		case VMEXIT_NO_CHANGE:
-		case VMEXIT_OTHERS:
-			break;
-		default:
-			print_panic("%s: Unknown handle type!\n", __func__);
-			VMM_DEADLOOP();
-			break;
+		if (vmexit_vmcs_handle_array[i].handler) {
+			vmexit_vmcs_handle_array[i].handler(gcpu, data, i);
 		}
 	}
 
-	/* TODO: add functions to handle VMEXIT_OTHERS */
+	/* Update Guest CR0/CR4 */
+	cr0_guest_write(gcpu, vmcs_read(vmcs, VMCS_GUEST_CR0));
+	cr4_guest_write(gcpu, vmcs_read(vmcs, VMCS_GUEST_CR4));
 }

--- a/vmm/modules/optee_guest/optee_guest.c
+++ b/vmm/modules/optee_guest/optee_guest.c
@@ -267,21 +267,6 @@ static void guest_register_vmcall_services()
 	vmcall_register(GUEST_OPTEE, OPTEE_VMCALL_SMC, smc_vmcall_exit);
 }
 
-#ifdef AP_START_IN_HLT
-static void set_guest0_aps_to_hlt_state(guest_cpu_handle_t gcpu, UNUSED void *pv)
-{
-	D(VMM_ASSERT(gcpu));
-
-	if (gcpu->guest->id == 0)
-	{
-		if (gcpu->id != 0)
-		{
-			vmcs_write(gcpu->vmcs, VMCS_GUEST_ACTIVITY_STATE, ACTIVITY_STATE_HLT);
-		}
-	}
-}
-#endif
-
 static void optee_set_gcpu_state(guest_cpu_handle_t gcpu, UNUSED void *pv)
 {
 	if (gcpu->guest->id == GUEST_OPTEE) {
@@ -322,10 +307,6 @@ void init_optee_guest(evmm_desc_t *evmm_desc)
 	/* Tee should not have X permission in REE memory. Set it to RW(0x3) */
 	create_guest(cpu_num, 0x3);
 	event_register(EVENT_GCPU_INIT, optee_set_gcpu_state);
-
-#ifdef AP_START_IN_HLT
-	event_register(EVENT_GCPU_MODULE_INIT, set_guest0_aps_to_hlt_state);
-#endif
 
 #ifdef PACK_OPTEE
 	relocate_optee_image();

--- a/vmm/modules/security_info/Makefile
+++ b/vmm/modules/security_info/Makefile
@@ -1,0 +1,10 @@
+################################################
+# Copyright (c) 2015-2019 Intel Corporation.
+# All rights reserved.
+#
+# SPDX-License-Identidfier: Apache-2.0
+#
+################################################
+
+CSOURCES = $(wildcard *.c)
+include $(PROJS)/rule.linux

--- a/vmm/modules/security_info/security_info.c
+++ b/vmm/modules/security_info/security_info.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2015-2019 Intel Corporation.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include "vmm_base.h"
+#include "vmm_arch.h"
+#include "vmm_asm.h"
+#include "vmm_objects.h"
+#include "dbg.h"
+#include "lib/util.h"
+#include "heap.h"
+#include "device_sec_info.h"
+#include "modules/security_info.h"
+
+#ifdef DERIVE_KEY
+#include "modules/crypto.h"
+#endif
+
+#ifdef DERIVE_KEY
+static int get_max_svn_index(device_sec_info_v0_t *sec_info)
+{
+	uint32_t i, max_svn_idx = 0;
+
+	if ((sec_info->num_seeds == 0) || (sec_info->num_seeds > BOOTLOADER_SEED_MAX_ENTRIES))
+		return -1;
+
+	for (i = 1; i < sec_info->num_seeds; i++) {
+		if (sec_info->dseed_list[i].cse_svn > sec_info->dseed_list[i - 1].cse_svn) {
+			max_svn_idx = i;
+		}
+	}
+
+	return max_svn_idx;
+}
+
+void key_derive(device_sec_info_v0_t *sec_info)
+{
+	const char salt[] = "Attestation Keybox Encryption Key";
+	const uint8_t *ikm;
+	uint8_t *prk;
+	uint32_t ikm_len;
+	int max_svn_idx;
+
+	max_svn_idx = get_max_svn_index(sec_info);
+	if (max_svn_idx < 0) {
+		print_info("VMM: failed to get max svn index\n");
+		memset(sec_info, 0, sizeof(device_sec_info_v0_t));
+		return;
+	}
+
+	ikm = sec_info->dseed_list[max_svn_idx].seed;
+	ikm_len = 32;
+
+	prk = sec_info->attkb_enc_key;
+
+	if (hmac_sha256((const uint8_t *)salt, sizeof(salt), ikm, ikm_len, prk) != 1) {
+		memset(sec_info, 0, sizeof(device_sec_info_v0_t));
+		print_panic("VMM: failed to derive key!\n");
+	}
+}
+#endif
+
+static uint32_t _mov_info(void *dest, void *src)
+{
+	uint32_t dev_sec_info_size = *((uint32_t *)src);
+
+	VMM_ASSERT_EX(!(dev_sec_info_size & 0x3ULL), "size of Tee boot info is not 32bit aligned!\n");
+
+	memcpy(dest, src, dev_sec_info_size);
+	memset(src, 0, dev_sec_info_size);
+	barrier();
+
+	return dev_sec_info_size;
+}
+
+uint32_t mov_sec_info(void *dest, void *src)
+{
+	static void *dev_sec_info;
+	uint32_t dev_sec_info_size;
+
+	D(VMM_ASSERT_EX(src || dest, "dest and src can't be NULL simultaneously!\n"));
+	D(VMM_ASSERT_EX((dest || (dev_sec_info == NULL)), "When dest is NULL, dev_sec_info MUST be NULL!\n"));
+	D(VMM_ASSERT_EX(src || dev_sec_info, "src and dev_sec_info can't be NULL simultaneously!\n"));
+
+	if (dest == INTERNAL) {
+		dev_sec_info_size = *((uint32_t *)src);
+		dev_sec_info = mem_alloc(dev_sec_info_size);
+		dest = dev_sec_info;
+	}
+
+	if (src == INTERNAL)
+		src = dev_sec_info;
+
+	dev_sec_info_size = _mov_info(dest, src);
+
+	if (src == dev_sec_info) {
+		mem_free(dev_sec_info);
+		dev_sec_info = NULL;
+	}
+
+#ifdef DERIVE_KEY
+	if (dest != dev_sec_info)
+		key_derive((device_sec_info_v0_t *)dest);
+#endif
+
+	return dev_sec_info_size;
+}

--- a/vmm/modules/trusty_guest/trusty_guest.c
+++ b/vmm/modules/trusty_guest/trusty_guest.c
@@ -465,21 +465,6 @@ static void guest_register_vmcall_services()
 #endif
 }
 
-#ifdef AP_START_IN_HLT
-static void set_guest0_aps_to_hlt_state(guest_cpu_handle_t gcpu, UNUSED void *pv)
-{
-	D(VMM_ASSERT(gcpu));
-
-	if (gcpu->guest->id == 0)
-	{
-		if (gcpu->id != 0)
-		{
-			vmcs_write(gcpu->vmcs, VMCS_GUEST_ACTIVITY_STATE, ACTIVITY_STATE_HLT);
-		}
-	}
-}
-#endif
-
 static void trusty_set_gcpu_state(guest_cpu_handle_t gcpu, UNUSED void *pv)
 {
 	if (gcpu->guest->id == GUEST_TRUSTY) {
@@ -533,10 +518,6 @@ void init_trusty_guest(evmm_desc_t *evmm_desc)
 	/* Tee should not have X permission in REE memory. Set it to RW(0x3) */
 	create_guest(cpu_num, 0x3);
 	event_register(EVENT_GCPU_INIT, trusty_set_gcpu_state);
-
-#ifdef AP_START_IN_HLT
-	event_register(EVENT_GCPU_MODULE_INIT, set_guest0_aps_to_hlt_state);
-#endif
 
 #ifdef MODULE_VMX_TIMER
 	event_register(EVENT_VMX_TIMER, vmx_timer_event_handler);

--- a/vmm/modules/trusty_guest/trusty_guest.c
+++ b/vmm/modules/trusty_guest/trusty_guest.c
@@ -227,6 +227,7 @@ static void setup_trusty_mem(void)
 	dev_sec_info_size = *((uint32_t *)trusty_desc->dev_sec_info);
 	memcpy((void *)trusty_desc->lk_file.runtime_addr, trusty_desc->dev_sec_info, dev_sec_info_size);
 	memset(trusty_desc->dev_sec_info, 0, dev_sec_info_size);
+	barrier();
 #endif
 
 #ifdef DERIVE_KEY
@@ -552,6 +553,7 @@ void init_trusty_guest(evmm_desc_t *evmm_desc)
 	dev_sec_info = mem_alloc(dev_sec_info_size);
 	memcpy(dev_sec_info, trusty_desc->dev_sec_info, dev_sec_info_size);
 	memset(trusty_desc->dev_sec_info, 0, dev_sec_info_size);
+	barrier();
 	trusty_desc->dev_sec_info = dev_sec_info;
 
 	set_initial_guest(guest_handle(GUEST_ANDROID));

--- a/vmm/modules/trusty_tee/Makefile
+++ b/vmm/modules/trusty_tee/Makefile
@@ -1,0 +1,10 @@
+################################################
+# Copyright (c) 2015-2019 Intel Corporation.
+# All rights reserved.
+#
+# SPDX-License-Identidfier: Apache-2.0
+#
+################################################
+
+CSOURCES = $(wildcard *.c)
+include $(PROJS)/rule.linux

--- a/vmm/modules/trusty_tee/trusty_info.h
+++ b/vmm/modules/trusty_tee/trusty_info.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015-2019 Intel Corporation.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef _TRUSTY_INFO_H_
+#define _TRUSTY_INFO_H_
+
+typedef struct {
+	/* Used to double check structures match */
+	uint32_t size_of_this_struct;
+
+	/* Total memory size for TEE */
+	uint32_t mem_size;
+
+	/* Used to calibrate TSC in TEE */
+	uint64_t calibrate_tsc_per_ms;
+
+	/* Used by keymaster */
+	uint64_t trusty_mem_base;
+
+	uint32_t sipi_ap_wkup_addr;
+	uint8_t  padding[4];
+} trusty_startup_info_t;
+
+/* Parameters from OSloader */
+typedef struct {
+	uint32_t size_of_this_struct;
+	uint32_t version;
+
+	/* 16MB under 4G */
+	uint32_t runtime_addr;
+
+	/* Entry address of trusty */
+	uint32_t entry_point;
+} trusty_boot_params_t;
+
+#endif

--- a/vmm/modules/trusty_tee/trusty_tee.c
+++ b/vmm/modules/trusty_tee/trusty_tee.c
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) 2015-2019 Intel Corporation.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include "vmm_base.h"
+#include "vmm_arch.h"
+#include "vmm_objects.h"
+#include "dbg.h"
+#include "lib/util.h"
+#include "heap.h"
+#include "gcpu.h"
+#include "guest.h"
+#include "trusty_info.h"
+#include "gcpu_inject_event.h"
+#include "device_sec_info.h"
+
+#include "lib/util.h"
+#include "lib/image_loader.h"
+#include "modules/vmcall.h"
+#include "modules/template_tee.h"
+
+#ifdef MODULE_VTD
+#include "modules/vtd.h"
+#endif
+
+#ifdef DERIVE_KEY
+#include "modules/crypto.h"
+#endif
+
+#ifdef MODULE_DEADLOOP
+#include "modules/deadloop.h"
+#endif
+
+enum {
+	TRUSTY_VMCALL_SMC       = 0x74727500,
+	TRUSTY_VMCALL_DUMP_INIT = 0x74727507,
+};
+
+static uint64_t g_init_rdi, g_init_rsp, g_init_rip;
+static guest_handle_t trusty_guest;
+/* For Tee early launch, dev_sec_info gets from evmm->trusty_desc which
+ * belongs to evmm stack, so no need to free it.
+ * For later launch, dev_sec_info is dynamic alloc during trusty_tee_init,
+ * then copy secure info to it. The memory should be free in first_smc_to_tee.
+*/
+static void *dev_sec_info;
+
+/* Reserved size for dev_sec_info/trusty_startup and Stack(1 page) */
+/*
+ * Trusty load size formula:
+ * MEM assigned to Trusty is 16MB size in total
+ * Stack size must be reserved
+ * Trusty Tee runtime memory will be calculated by Trusty itself
+ * The rest region can be use to load Trusty image
+ * ------------------------
+ *     ^     |          |
+ *   Stack   |          |
+ * ----------|          |
+ *     ^     |          |
+ *     |     |          |
+ *   HEAP    |          |
+ *     |     |    M     |
+ *  ---------|          |
+ *     ^     |    E     |
+ *     |     |          |
+ *   Trusty  |    M     |
+ *   load    |          |
+ *   size    |          |
+ *     |     |          |
+ *  ---------|          |
+ *     ^     |          |
+ *  Boot info|          |
+ * ------------------------
+ */
+
+static uint64_t relocate_trusty_image(module_file_info_t *tee_file)
+{
+	boolean_t ret = FALSE;
+	uint64_t entry_point;
+
+	/* lk region: first page is trusty info, last page is stack. */
+	tee_file->runtime_addr += PAGE_4K_SIZE;
+	tee_file->runtime_total_size -= PAGE_4K_SIZE;
+
+	ret = relocate_elf_image(tee_file, &entry_point);
+	if (!ret) {
+		print_trace("Failed to load ELF file. Try multiboot now!\n");
+		ret = relocate_multiboot_image((uint64_t *)tee_file->loadtime_addr,
+				tee_file->loadtime_size, &entry_point);
+	}
+	VMM_ASSERT_EX(ret, "Failed to relocate Trusty image!\n");
+
+	/* restore lk runtime address and total size */
+	tee_file->runtime_addr -= PAGE_4K_SIZE;
+	tee_file->runtime_total_size += PAGE_4K_SIZE;
+
+	return entry_point;
+}
+
+#ifdef DERIVE_KEY
+static int get_max_svn_index(device_sec_info_v0_t *sec_info)
+{
+	uint32_t i, max_svn_idx = 0;
+
+	if ((sec_info->num_seeds == 0) || (sec_info->num_seeds > BOOTLOADER_SEED_MAX_ENTRIES))
+		return -1;
+
+	for (i = 1; i < sec_info->num_seeds; i++) {
+		if (sec_info->dseed_list[i].cse_svn > sec_info->dseed_list[i - 1].cse_svn) {
+			max_svn_idx = i;
+		}
+	}
+
+	return max_svn_idx;
+}
+
+static void key_derive(device_sec_info_v0_t *sec_info)
+{
+	const char salt[] = "Attestation Keybox Encryption Key";
+	const uint8_t *ikm;
+	uint8_t *prk;
+	uint32_t ikm_len;
+	int max_svn_idx;
+
+	max_svn_idx = get_max_svn_index(sec_info);
+	if (max_svn_idx < 0) {
+		print_info("VMM: failed to get max svn index\n");
+		memset(sec_info, 0, sizeof(device_sec_info_v0_t));
+		return;
+	}
+
+	ikm = sec_info->dseed_list[max_svn_idx].seed;
+	ikm_len = 32;
+
+	prk = sec_info->attkb_enc_key;
+
+	if (hmac_sha256((const uint8_t *)salt, sizeof(salt), ikm, ikm_len, prk) != 1) {
+		memset(sec_info, 0, sizeof(device_sec_info_v0_t));
+		print_panic("VMM: failed to derive key!\n");
+	}
+}
+#endif
+
+/* Set up trusty device security info and trusty startup info */
+static uint64_t setup_trusty_mem(uint64_t runtime_addr, uint64_t runtime_total_size)
+{
+	uint32_t dev_sec_info_size;
+	trusty_startup_info_t *trusty_para;
+
+	/* Setup trusty boot info */
+	dev_sec_info_size = *((uint32_t *)dev_sec_info);
+	memcpy((void *)runtime_addr, dev_sec_info, dev_sec_info_size);
+	memset(dev_sec_info, 0, dev_sec_info_size);
+	barrier();
+
+#ifdef DERIVE_KEY
+	key_derive((device_sec_info_v0_t *)runtime_addr);
+#endif
+
+	/* Setup trusty startup info */
+	trusty_para = (trusty_startup_info_t *)ALIGN_F(runtime_addr + dev_sec_info_size, 8);
+	VMM_ASSERT_EX(((uint64_t)trusty_para + sizeof(trusty_startup_info_t)) <
+			(runtime_addr + PAGE_4K_SIZE),
+			"size of (dev_sec_info+trusty_startup_info) exceeds the reserved 4K size!\n");
+	trusty_para->size_of_this_struct  = sizeof(trusty_startup_info_t);
+	trusty_para->mem_size             = runtime_total_size;
+	trusty_para->calibrate_tsc_per_ms = tsc_per_ms;
+	trusty_para->trusty_mem_base      = runtime_addr;
+
+	return (uint64_t)trusty_para;
+}
+
+static void before_launching_tee(guest_cpu_handle_t gcpu_trusty)
+{
+	gcpu_set_gp_reg(gcpu_trusty, REG_RDI, g_init_rdi);
+	gcpu_set_gp_reg(gcpu_trusty, REG_RSP, g_init_rsp);
+	vmcs_write(gcpu_trusty->vmcs, VMCS_GUEST_RIP, g_init_rip);
+}
+
+static uint64_t parse_trusty_boot_param(guest_cpu_handle_t gcpu, uint64_t *runtime_addr, uint64_t *runtime_total_size)
+{
+	uint64_t rdi;
+	trusty_boot_params_t *trusty_boot_params;
+
+	/* avoid warning -Wbad-function-cast */
+	rdi = gcpu_get_gp_reg(gcpu, REG_RDI);
+	VMM_ASSERT_EX(rdi, "Invalid trusty boot params\n");
+
+	/* trusty_boot_params is passed from OSloader */
+	trusty_boot_params = (trusty_boot_params_t *)rdi;
+
+	*runtime_addr = trusty_boot_params->runtime_addr;
+	/* osloader alloc 16M memory for trusty */
+	*runtime_total_size = 16 MEGABYTE;
+
+	return trusty_boot_params->entry_point;
+}
+
+static void first_smc_to_tee(guest_cpu_handle_t gcpu_ree)
+{
+	uint64_t runtime_addr, runtime_total_size;
+
+	/* 1. Get trusty info from osloader then set trusty startup&sec info.
+	 * 2. Set RIP RDI and RSP
+	 */
+	g_init_rip = parse_trusty_boot_param(gcpu_ree, &runtime_addr, &runtime_total_size);
+	g_init_rdi = setup_trusty_mem(runtime_addr, runtime_total_size);
+	g_init_rsp = runtime_addr + runtime_total_size;
+
+	mem_free(dev_sec_info);
+	dev_sec_info = NULL;
+
+	launch_tee(trusty_guest, runtime_addr, runtime_total_size);
+}
+
+static void trusty_vmcall_dump_init(guest_cpu_handle_t gcpu)
+{
+#ifdef MODULE_DEADLOOP
+	uint64_t dump_gva;
+
+	D(VMM_ASSERT(gcpu->guest->id == GUEST_REE));
+
+	if (!gcpu_in_ring0(gcpu)) {
+		gcpu_inject_ud(gcpu);
+		return;
+	}
+
+	/* RDI stored the pointer of deadloop_dump_t which allocated by the guest */
+	dump_gva = gcpu_get_gp_reg(gcpu, REG_RDI);
+
+	/* register event deadloop */
+	if (!deadloop_setup(gcpu, dump_gva))
+		return;
+#endif
+	/* set the return value */
+	gcpu_set_gp_reg(gcpu, REG_RAX, 0);
+}
+
+static void *sensitive_info;
+static void trusty_erase_sensetive_info(void)
+{
+#ifndef DEBUG //in DEBUG build, access from VMM to Trusty will be removed. so, only erase sensetive info in RELEASE build
+	memset(sensitive_info, 0, PAGE_4K_SIZE);
+#endif
+}
+
+void trusty_register_deadloop_handler(evmm_desc_t *evmm_desc)
+{
+	D(VMM_ASSERT_EX(evmm_desc, "evmm_desc is NULL\n"));
+	sensitive_info = (void *)evmm_desc->trusty_tee_desc.tee_file.runtime_addr;
+
+	register_final_deadloop_handler(trusty_erase_sensetive_info);
+}
+
+#ifdef AP_START_IN_HLT
+static void set_guest0_aps_to_hlt_state(guest_cpu_handle_t gcpu, UNUSED void *pv)
+{
+	D(VMM_ASSERT(gcpu));
+
+	if (gcpu->guest->id == 0) {
+		if (gcpu->id != 0) {
+			vmcs_write(gcpu->vmcs, VMCS_GUEST_ACTIVITY_STATE, ACTIVITY_STATE_HLT);
+		}
+	}
+}
+#endif
+
+void init_trusty_tee(evmm_desc_t *evmm_desc)
+{
+	tee_config_t trusty_cfg;
+	tee_desc_t *trusty_desc;
+	uint32_t dev_sec_info_size;
+	uint8_t smc_param_to_tee[] = {REG_RDI, REG_RSI, REG_RDX, REG_RBX};
+	uint8_t smc_param_to_ree[] = {REG_RDI, REG_RSI, REG_RDX, REG_RBX};
+
+	D(VMM_ASSERT_EX(evmm_desc, "evmm_desc is NULL\n"));
+
+	trusty_desc = (tee_desc_t *)&evmm_desc->trusty_tee_desc;
+	D(VMM_ASSERT(trusty_desc));
+
+	print_trace("Init trusty guest\n");
+
+	memset(&trusty_cfg, 0, sizeof(tee_config_t));
+
+	trusty_cfg.tee_name = "trusty_tee";
+	trusty_cfg.single_gcpu = TRUE;
+	trusty_cfg.smc_vmcall_id = TRUSTY_VMCALL_SMC;
+
+	fill_smc_param_to_tee(trusty_cfg, smc_param_to_tee);
+	fill_smc_param_from_tee(trusty_cfg, smc_param_to_ree);
+
+#ifdef PACK_LK
+	trusty_cfg.launch_tee_first = TRUE;
+#else
+	trusty_cfg.launch_tee_first = FALSE;
+#endif
+
+	trusty_cfg.before_launching_tee = before_launching_tee;
+	trusty_cfg.tee_bsp_status = MODE_32BIT;
+	trusty_cfg.tee_ap_status = HLT;
+
+	if (trusty_cfg.launch_tee_first) {
+		trusty_cfg.tee_runtime_addr = trusty_desc->tee_file.runtime_addr;
+		trusty_cfg.tee_runtime_size = trusty_desc->tee_file.runtime_total_size;
+
+		/* Set RIP RDI and RSP */
+		g_init_rip = relocate_trusty_image(&trusty_desc->tee_file);
+		g_init_rdi = setup_trusty_mem(trusty_desc->tee_file.runtime_addr, trusty_desc->tee_file.runtime_total_size);
+		g_init_rsp = trusty_desc->tee_file.runtime_addr + trusty_desc->tee_file.runtime_total_size;
+
+		dev_sec_info = trusty_desc->dev_sec_info;
+	} else {
+		trusty_cfg.first_smc_to_tee = first_smc_to_tee;
+
+		/* Copy dev_sec_info from loader to VMM's memory */
+		dev_sec_info_size = *((uint32_t *)trusty_desc->dev_sec_info);
+		VMM_ASSERT_EX(!(dev_sec_info_size & 0x3ULL), "size of trusty boot info is not 32bit aligned!\n");
+		dev_sec_info = mem_alloc(dev_sec_info_size);
+		memcpy(dev_sec_info, trusty_desc->dev_sec_info, dev_sec_info_size);
+		memset(trusty_desc->dev_sec_info, 0, dev_sec_info_size);
+		barrier();
+	}
+
+	trusty_guest = create_tee(&trusty_cfg);
+	VMM_ASSERT_EX(trusty_guest, "Failed to create trusty guest!\n");
+
+#ifdef AP_START_IN_HLT
+	event_register(EVENT_GCPU_MODULE_INIT, set_guest0_aps_to_hlt_state);
+#endif
+
+#ifdef DMA_FROM_CSE
+	vtd_assign_dev(gid2did(trusty_guest->id), DMA_FROM_CSE);
+#endif
+
+	vmcall_register(GUEST_REE, TRUSTY_VMCALL_DUMP_INIT, trusty_vmcall_dump_init);
+
+	return;
+}

--- a/vmm/modules/trusty_tee/trusty_tee.c
+++ b/vmm/modules/trusty_tee/trusty_tee.c
@@ -192,19 +192,6 @@ void trusty_register_deadloop_handler(evmm_desc_t *evmm_desc)
 	register_final_deadloop_handler(trusty_erase_sensetive_info);
 }
 
-#ifdef AP_START_IN_HLT
-static void set_guest0_aps_to_hlt_state(guest_cpu_handle_t gcpu, UNUSED void *pv)
-{
-	D(VMM_ASSERT(gcpu));
-
-	if (gcpu->guest->id == 0) {
-		if (gcpu->id != 0) {
-			vmcs_write(gcpu->vmcs, VMCS_GUEST_ACTIVITY_STATE, ACTIVITY_STATE_HLT);
-		}
-	}
-}
-#endif
-
 void init_trusty_tee(evmm_desc_t *evmm_desc)
 {
 	tee_config_t trusty_cfg;
@@ -256,10 +243,6 @@ void init_trusty_tee(evmm_desc_t *evmm_desc)
 
 	trusty_guest = create_tee(&trusty_cfg);
 	VMM_ASSERT_EX(trusty_guest, "Failed to create trusty guest!\n");
-
-#ifdef AP_START_IN_HLT
-	event_register(EVENT_GCPU_MODULE_INIT, set_guest0_aps_to_hlt_state);
-#endif
 
 #ifdef DMA_FROM_CSE
 	vtd_assign_dev(gid2did(trusty_guest->id), DMA_FROM_CSE);


### PR DESCRIPTION
The patches upstream is for 
add memory barrier when scrub sensetive data.
refine build flag
refine handle VMEXIT_OTHERS
add module of Trusty based on template tee framework

Signed-off-by: Sheng Wei w.sheng@intel.com