### PR TITLE
Add config for security test.

### DIFF
--- a/product/celadon_64.cfg
+++ b/product/celadon_64.cfg
@@ -26,3 +26,13 @@ EVMM_CMPL_FLAGS += \
 EVMM_CMPL_FLAGS += \
  -DEVMM_PKG_BIN_SIZE=0x600000
 
+#Please keep below lines at the bottom of this file.
+ifeq ($(SECURITY_TEST),true)
+EVMM_CMPL_FLAGS += \
+ -DMODULE_SECURITY_TEST
+
+ifeq ($(DISABLE_VTD),true)
+TEMP_FLAGS := $(EVMM_CMPL_FLAGS)
+EVMM_CMPL_FLAGS = $(filter-out -DMODULE_VTD, $(TEMP_FLAGS))
+endif
+endif

--- a/product/celadon_apl.cfg
+++ b/product/celadon_apl.cfg
@@ -26,3 +26,13 @@ EVMM_CMPL_FLAGS += \
 EVMM_CMPL_FLAGS += \
  -DEVMM_PKG_BIN_SIZE=0x600000
 
+#Please keep below lines at the bottom of this file.
+ifeq ($(SECURITY_TEST),true)
+EVMM_CMPL_FLAGS += \
+ -DMODULE_SECURITY_TEST
+
+ifeq ($(DISABLE_VTD),true)
+TEMP_FLAGS := $(EVMM_CMPL_FLAGS)
+EVMM_CMPL_FLAGS = $(filter-out -DMODULE_VTD, $(TEMP_FLAGS))
+endif
+endif

--- a/product/celadon_clk.cfg
+++ b/product/celadon_clk.cfg
@@ -26,3 +26,13 @@ EVMM_CMPL_FLAGS += \
 EVMM_CMPL_FLAGS += \
  -DEVMM_PKG_BIN_SIZE=0x600000
 
+#Please keep below lines at the bottom of this file.
+ifeq ($(SECURITY_TEST),true)
+EVMM_CMPL_FLAGS += \
+ -DMODULE_SECURITY_TEST
+
+ifeq ($(DISABLE_VTD),true)
+TEMP_FLAGS := $(EVMM_CMPL_FLAGS)
+EVMM_CMPL_FLAGS = $(filter-out -DMODULE_VTD, $(TEMP_FLAGS))
+endif
+endif

--- a/product/celadon_kbl.cfg
+++ b/product/celadon_kbl.cfg
@@ -25,3 +25,13 @@ EVMM_CMPL_FLAGS += \
 EVMM_CMPL_FLAGS += \
  -DEVMM_PKG_BIN_SIZE=0x600000
 
+#Please keep below lines at the bottom of this file.
+ifeq ($(SECURITY_TEST),true)
+EVMM_CMPL_FLAGS += \
+ -DMODULE_SECURITY_TEST
+
+ifeq ($(DISABLE_VTD),true)
+TEMP_FLAGS := $(EVMM_CMPL_FLAGS)
+EVMM_CMPL_FLAGS = $(filter-out -DMODULE_VTD, $(TEMP_FLAGS))
+endif
+endif

--- a/vmm/modules/trusty_tee/trusty_tee.c
+++ b/vmm/modules/trusty_tee/trusty_tee.c
@@ -244,8 +244,10 @@ void init_trusty_tee(evmm_desc_t *evmm_desc)
 	trusty_guest = create_tee(&trusty_cfg);
 	VMM_ASSERT_EX(trusty_guest, "Failed to create trusty guest!\n");
 
+#ifdef MODULE_VTD
 #ifdef DMA_FROM_CSE
 	vtd_assign_dev(gid2did(trusty_guest->id), DMA_FROM_CSE);
+#endif
 #endif
 
 	vmcall_register(GUEST_REE, TRUSTY_VMCALL_DUMP_INIT, trusty_vmcall_dump_init);


### PR DESCRIPTION
Add switches to enable security_test module and disable VTD module.
Then we can append SECURITY_TEST=true and DISABLE_VTD=true as
parameters after android make command.

Change-Id: I87474a4d6af2194bd384584bed8a8ca24b331bde
Signed-off-by: Duan Honghui Honghuix.duan@intel.com