### PR TITLE
vmm: refine perf_ctrl_isolation module

### DIFF
--- a/vmm/modules/perf_ctrl_isolation/perf_ctrl_isolation.c
+++ b/vmm/modules/perf_ctrl_isolation/perf_ctrl_isolation.c
@@ -64,12 +64,16 @@ static void perf_ctrl_isolation_gcpu_init(guest_cpu_handle_t gcpu, UNUSED void *
 
 void msr_perf_ctrl_isolation_init(void)
 {
-	VMM_ASSERT_EX(get_entryctl_cap(NULL) & ENTRY_LOAD_IA32_PERF_CTRL,
-			"ENTRY_LOAD_IA32_PERF_CTRL not supported!\n");
-	VMM_ASSERT_EX(get_exitctl_cap(NULL) & EXIT_LOAD_IA32_PERF_CTRL,
-			"EXIT_LOAD_IA32_PERF_CTRL not supported!\n");
+	if (!(get_entryctl_cap(NULL) & ENTRY_LOAD_IA32_PERF_CTRL)) {
+		print_warn("ENTRY_LOAD_IA32_PERF_CTRL not supported! IA32_PERF_CTRL MSR will not isolated!");
+		return;
+	}
+
+	if (!(get_exitctl_cap(NULL) & EXIT_LOAD_IA32_PERF_CTRL)) {
+		print_warn("EXIT_LOAD_IA32_PERF_CTRL not supported! IA32_PERF_CTRL MSR will not isolated!");
+		return;
+	}
 
 	event_register(EVENT_GUEST_MODULE_INIT, guest_msr_perf_ctrl_monitor_setup);
 	event_register(EVENT_GCPU_MODULE_INIT, perf_ctrl_isolation_gcpu_init);
-
 }


### PR DESCRIPTION
No assert when cpu does not support IA32_PERF_GLOBAL_CTRL load/store
on vmentry/vmexit. Replace the assertion with warning log.

Signed-off-by: Qi Yadong <yadong.qi@intel.com>