### PR TITLE
loader: remove ULL suffix from assembly header file

### DIFF
--- a/loader/stage0/entry/entry_asm.h
+++ b/loader/stage0/entry/entry_asm.h
@@ -9,7 +9,7 @@
 #ifndef _ENTRY_ASM_H_
 #define _ENTRY_ASM_H_
 
-#define TOS_HEADER_MAGIC              0x6d6d76656967616dULL
+#define TOS_HEADER_MAGIC              0x6d6d76656967616d
 #define TOS_HEADER_VERSION            1
 #define TOS_IMAGE_VERSION             1
 #define TOS_STARTUP_VERSION           3


### PR DESCRIPTION
"ULL" suffix should be removed from macro definition to
adapt some old version of GCC/GNU AS.

Signed-off-by: Zhong,Fangjian <fangjian.zhong@intel.com>