### PR TITLE
vmm: Add get secinfo vmcall and update Trusty boot environment from 32-bit to 64-bit

### DIFF
--- a/loader/stage1/stage1.c
+++ b/loader/stage1/stage1.c
@@ -139,8 +139,8 @@ uint32_t stage1_main(evmm_desc_t *xd)
 #endif
 
 #ifdef MODULE_TEMPLATE_TEE
-	if (evmm_desc->x64_cr3 == 0)
-		evmm_desc->x64_cr3 = asm_get_cr3();
+	if (xd->x64_cr3 == 0)
+		xd->x64_cr3 = asm_get_cr3();
 #endif
 
 	/* Load evmm image */

--- a/packer/Makefile
+++ b/packer/Makefile
@@ -54,7 +54,7 @@ $(TARGET): $(COBJS)
 
 pack:$(TARGET)
 ifneq (, $(findstring -DPACK_LK, $(EVMM_CMPL_FLAGS)))
-	if [ $(LKBIN_DIR) ]; then cp $(LKBIN_DIR)lk.elf $(BUILD_DIR); fi
+	if [ $(LKBIN_DIR) ]; then cp $(LKBIN_DIR)lk.bin $(BUILD_DIR); fi
 else
 ifneq (, $(findstring -DPACK_OPTEE, $(EVMM_CMPL_FLAGS)))
 	if [ $(OPTEEBIN_DIR) ]; then cp $(OPTEEBIN_DIR)tee-pager.bin $(BUILD_DIR); fi

--- a/packer/evmm_packer.c
+++ b/packer/evmm_packer.c
@@ -33,7 +33,7 @@ static char* file_list[] = {
 	"stage1.bin",
 	"evmm.elf",
 #if (defined (MODULE_TRUSTY_GUEST) || defined (MODULE_TRUSTY_TEE)) && defined (PACK_LK)
-	"lk.elf",
+	"lk.bin",
 #endif
 
 #if  defined (MODULE_OPTEE_GUEST) && defined (PACK_OPTEE)

--- a/packer/readme.txt
+++ b/packer/readme.txt
@@ -2,7 +2,7 @@ this tool:
 1. is used to append all binaries (e.g. stage0.bin, stage1, evmm) to evmm_pkg.bin
 2. after that it will update the file offset header in evmm_pkg.bin file.
 3. also, it does build time oversize check, to find error as early as possible.
-4. will pack secondary guest image(lk.elf) if needed.
+4. will pack secondary guest image(lk.bin) if needed.
 
 
   --- end of file ---

--- a/readme.txt
+++ b/readme.txt
@@ -159,7 +159,7 @@ Config files
 			- DMA_FROM_CSE
 				Description: Optional, allow CSE device access multi guests' memory by DMA. This macro should take the value of PCI device id(PCI_DEV(Bus:Device:Func));
 		- PACK_LK
-			Description: pack lk.elf into evmm_pkg.bin
+			Description: pack lk.bin into evmm_pkg.bin
 			- DERIVE_KEY
 				Description: Derive key
 				Dependency: MODULE_CRYPTO

--- a/vmm/guest/gcpu_state.c
+++ b/vmm/guest/gcpu_state.c
@@ -407,7 +407,7 @@ void gcpu_set_64bit_state(guest_cpu_handle_t gcpu, uint64_t x86_cr3)
 
 	vmcs_write(vmcs, VMCS_GUEST_CR0, CR0_PE|CR0_ET|CR0_NE|CR0_PG);
 	vmcs_write(vmcs, VMCS_GUEST_CR3, x86_cr3);
-	vmcs_write(vmcs, VMCS_GUEST_CR4, CR4_PAE|CR4_VMXE);
+	vmcs_write(vmcs, VMCS_GUEST_CR4, CR4_PAE);
 
 	vmcs_write(vmcs, VMCS_GUEST_GDTR_BASE, 0);
 	vmcs_write(vmcs, VMCS_GUEST_GDTR_LIMIT, 0x17);
@@ -428,6 +428,6 @@ void gcpu_set_64bit_state(guest_cpu_handle_t gcpu, uint64_t x86_cr3)
 
 	/* set state in vmenter control fields */
 	cr0_guest_write(gcpu, CR0_PE|CR0_ET|CR0_NE|CR0_PG);
-	cr4_guest_write(gcpu, CR4_PAE|CR4_VMXE);
+	cr4_guest_write(gcpu, CR4_PAE);
 	gcpu_update_guest_mode(gcpu);
 }

--- a/vmm/include/modules/security_info.h
+++ b/vmm/include/modules/security_info.h
@@ -17,15 +17,34 @@
 
 #define INTERNAL NULL
 
-/* Move security info from src to dest. All parameters can't be NULL. Returns number of byte moved */
+/*
+ * Move security info from src to dest. All parameters can't be NULL.
+ * Returns number of byte moved
+ */
 uint32_t mov_secinfo(void *dest, void *src);
 
-/* Move security info from src to memory which will be allocated in the function,
-   returns the allocated memory address */
+/*
+ * Move security info from src to memory which will be allocated in
+ * the function, returns the allocated memory address
+ */
 void *mov_secinfo_to_internal(void *src);
 
-/* Move security info from allocated memory which gets from mov_secinfo_to_internal() to dest.
-  Then the allocated memory will be freed. All parameters can't be NULL. Returns number of byte moved */
-uint32_t mov_secinfo_from_internal(void *dest, void *handle);
+/*
+ * Move security info from allocated memory which gets from
+ * mov_secinfo_to_internal() to dest. Then the allocated memory will
+ * be freed. All parameters can't be NULL. Returns number of byte moved.
+ */
+uint32_t mov_secinfo_from_internal(void *dest, void* handle);
 
+/*
+ * Move security info from allocated memory which gets from
+ * mov_secinfo_to_internal() to dest. Then the allocated memory will
+ * be freed no matter whether succeed or failed to move secinfo.
+ * All parameters can't be NULL. Returns TRUE if succeed to move,
+ * else returns FALSE.
+ */
+boolean_t mov_secinfo_to_gva(
+		guest_cpu_handle_t gcpu,
+		uint64_t dst_gva,
+		uint64_t src_hva);
 #endif

--- a/vmm/modules/trusty_tee/trusty_info.h
+++ b/vmm/modules/trusty_tee/trusty_info.h
@@ -9,23 +9,6 @@
 #ifndef _TRUSTY_INFO_H_
 #define _TRUSTY_INFO_H_
 
-typedef struct {
-	/* Used to double check structures match */
-	uint32_t size_of_this_struct;
-
-	/* Total memory size for TEE */
-	uint32_t mem_size;
-
-	/* Used to calibrate TSC in TEE */
-	uint64_t calibrate_tsc_per_ms;
-
-	/* Used by keymaster */
-	uint64_t trusty_mem_base;
-
-	uint32_t sipi_ap_wkup_addr;
-	uint8_t  padding[4];
-} trusty_startup_info_t;
-
 /* Parameters from OSloader
  * change history:
  * version 0 : init version


### PR DESCRIPTION
New hypercall is introduced to get secinfo for Trusty TEE guest.

With this change, eVmm stores secinfo which provided by bootloader, and
copies secinfo to Trusty TEE memory region. Trusty TEE guest can also
invoke hypercall to get secinfo from eVMM.

This hypercall can only be invoked from Trusty TEE guest for only one
time. And eVmm would erase secinfo once Trusty TEE guest invoked this
hypercall.

Signed-off-by: Zhong,Fangjian <fangjian.zhong@intel.com>