### PR TITLE
lib: initialize local variable before use

### DIFF
--- a/lib/image_loader/elf_ld/elf_ld.c
+++ b/lib/image_loader/elf_ld/elf_ld.c
@@ -37,7 +37,7 @@ elf_get_segment_info(const void *p_image,
 
 boolean_t get_image_section(void *image_base, uint16_t index, image_section_info_t *info)
 {
-	elf_segment_info_t segment_info;
+	elf_segment_info_t segment_info = { NULL, 0, 0 };
 
 	if (!elf_get_segment_info(image_base, index, &segment_info))
 		return FALSE;


### PR DESCRIPTION
The local variable must be initialized before use.

Signed-off-by: Qi, Yadong <yadong.qi@intel.com>