### PR TITLE
Enable workaround for INIT missing

### DIFF
--- a/product/celadon_64.cfg
+++ b/product/celadon_64.cfg
@@ -25,6 +25,9 @@ EVMM_CMPL_FLAGS += \
  -DAP_START_IN_HLT
 
 EVMM_CMPL_FLAGS += \
+ -DWORKAROUND_MISSING_INIT_SIGNAL
+
+EVMM_CMPL_FLAGS += \
  -DEVMM_PKG_BIN_SIZE=0x600000
 
 #Please keep below lines at the bottom of this file.


### PR DESCRIPTION
Currently, workaround the INIT signal missing for CiV. In future,
We may remove this workaround if KVM has formal fix of emulating
INIT/SIPI vmexit to L2 Hypervisor.

Signed-off-by: Qi, Yadong <yadong.qi@intel.com>