### PR TITLE
!!DO NOT MERGE!! Disale ACPI related features

### DIFF
--- a/product/celadon_64.cfg
+++ b/product/celadon_64.cfg
@@ -1,12 +1,12 @@
 EVMM_CMPL_FLAGS :=
-EVMM_CMPL_FLAGS += -DLOG_LEVEL=0
+EVMM_CMPL_FLAGS += -DLOG_LEVEL=3
 
 include $(PROJS)/product/board/cel_nuc.cfg
 
 include $(PROJS)/product/feature/trusty_tee.cfg
 include $(PROJS)/product/feature/isolation.cfg
 include $(PROJS)/product/feature/security.cfg
-include $(PROJS)/product/feature/suspend.cfg
+#include $(PROJS)/product/feature/suspend.cfg
 
 export LOADER_STAGE0_SUB = efi
 
@@ -15,11 +15,12 @@ EVMM_CMPL_FLAGS += \
  -DMODULE_UCODE_UPDATE \
  -DMODULE_TSC \
  -DMODULE_VMEXIT_INIT\
- -DPACK_LK \
- -DMODULE_ACPI \
- -DMODULE_VTD \
- -DDMAR_MAX_ENGINE=16 \
- -DSKIP_DMAR_GPU
+ -DPACK_LK
+
+ #-DMODULE_ACPI \
+ #-DMODULE_VTD \
+ #-DDMAR_MAX_ENGINE=16 \
+ #-DSKIP_DMAR_GPU
 
 EVMM_CMPL_FLAGS += \
  -DAP_START_IN_HLT
@@ -29,6 +30,10 @@ EVMM_CMPL_FLAGS += \
 
 EVMM_CMPL_FLAGS += \
  -DEVMM_PKG_BIN_SIZE=0x600000
+
+EVMM_CMPL_FLAGS += \
+ -DLIB_PRINT \
+ -DSERIAL_IO=0x3f8
 
 #Please keep below lines at the bottom of this file.
 ifeq ($(SECURITY_TEST),true)


### PR DESCRIPTION
When OVM runs on top of crosvm, ACPI table has not been initialized
correctly. eVmm needs to traverse ACPI table (also DSDT table) to
acquire DMAR engine for VT-D proection, and acquire suspend support.

With this limitation of ACPI table, VT-D and suspend features are
disabled for current stage. Once ACPI table is setup correctly, we need
to revert this patch.

Tracked-On: