### PR TITLE
Use prebuilts clang instead of gcc to build evmmpacker

### DIFF
--- a/include/vmm_base.h
+++ b/include/vmm_base.h
@@ -37,7 +37,11 @@ typedef struct {
 #define FALSE 0
 #define TRUE 1
 
+// NULL is defined in prebuilts clang stl header
+// so redefining here within a include guard 
+#ifndef NULL
 #define NULL ((void *)0)
+#endif
 
 #define ALIGN_B(value, align) \
 	((uint64_t)(value) & (~((uint64_t)(align) - 1ULL)))

--- a/packer/Makefile
+++ b/packer/Makefile
@@ -6,8 +6,8 @@
 #
 ################################################
 
-#using local gcc for evmmpacker
-export CC = gcc
+#using local clang for evmmpacker
+export CC = clang
 
 OUTDIR = $(BUILD_DIR)packer/
 $(shell mkdir -p $(OUTDIR))
@@ -35,6 +35,7 @@ CFLAGS = $(EVMM_CMPL_FLAGS) -s -static -Werror
 endif
 
 CFLAGS += $(INCLUDES)
+CFLAGS += -Qunused-arguments
 
 COBJS = $(addprefix $(OUTDIR), $(notdir $(patsubst %.c, %.o, $(CSOURCES))))
 


### PR DESCRIPTION
This is required to enable setup path for
Android 11

Tracked-On: OAM-95316
Signed-off-by: yaravapa <yasoda.aravapalli@intel.com>