### PR TITLE
Fix stage0 loads stage1 binary failure

### DIFF
--- a/loader/stage0/grub-qemu/linker.lds
+++ b/loader/stage0/grub-qemu/linker.lds
@@ -33,6 +33,9 @@ SECTIONS
     /* merge .rodata into .text */
     *(.rodata .rodata.* .gnu.linkonce.r.*)
 
+    /* merge global variables */
+    *(.data)
+
     /* merge .bss into .text */
     *(.bss .bss.* .gnu.linkonce.b.* COMMON)
   } =0x90909090


### PR DESCRIPTION
With Clang verison r416183c1, global variable of serial port device
resides in data section. However, data section is omiited in stage0
linker script.

In this case, when we init serial port device, data section will be
touched. Since there is no data section, and stage1 raw binary is
appended to stage0 raw binary, then file header of stage1 is
overwritten.

To fix this issue, we specify .data section to .text section.