### PR TITLE
vtd: refine vtd late activate process

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -175,6 +175,8 @@ Config files
 				Description: Workaround for bug OAM-42091, conflict with GFX.
 			- MULTI_GUEST_DMA
 				Description: Optional, allow a device access multi guests' memory by DMA.
+			- VTD_FORCE_ACTIVATE_ON_BOOT
+				Description: Optional, force to activate vt-d engines on eVMM's boot stage.
 
 	- MODULE_DEV_BLK
 		Description: provide API to block access to devices from guests.

--- a/vmm/main.c
+++ b/vmm/main.c
@@ -519,12 +519,10 @@ void vmm_main_continue(vmm_input_params_t *vmm_input_params)
 		BSP_SET_STAGE(STAGE_INIT_GUEST);
 
 #ifdef MODULE_VTD
-		/* vtd_done() will not affect AP boot.
-		 * since BSP needs to wait for AP before gcpu_resume(), put vtd_done()
+		/* vtd_activate() will not affect AP boot.
+		 * since BSP needs to wait for AP before gcpu_resume(), put vtd_activate()
 		 * here will take BSP more time and reduce the wait time for AP. */
-#ifndef ACTIVATE_VTD_BY_VMCALL
 		vtd_activate();
-#endif
 #endif
 
 #ifdef MODULE_BLOCK_NPK


### PR DESCRIPTION
Add function to detect whether translation is already enabled by
BIOS, if yes, then do not activate VT-d at boot stage.

Signed-off-by: Yadong Qi <yadong.qi@intel.com>