### PR TITLE
Fix static scan issues

### DIFF
--- a/packer/evmm_packer.c
+++ b/packer/evmm_packer.c
@@ -69,6 +69,7 @@ static void *read_file_to_buf(const char *fname, uint32_t buf_size)
 {
 	FILE *f = fopen(fname, "r");
 	void *pbuf = NULL;
+	size_t num_read = 0;
 
 	if (!f) {
 		printf("!ERROR(packer): failed to open %s\r\n", fname);
@@ -81,17 +82,18 @@ static void *read_file_to_buf(const char *fname, uint32_t buf_size)
 		goto error;
 	}
 
-	fread(pbuf, buf_size, 1, f);
-	if (ferror(f) != 0 ||
-		feof(f) != 0) {
-		printf("!ERROR(packer): failed to read %d bytes in file %s\r\n",
-			buf_size,
-			fname);
+	num_read = fread(pbuf, buf_size, 1, f);
+	if (num_read != 1) {
+		if (ferror(f) != 0 || feof(f) != 0) {
+			printf("!ERROR(packer): failed to read %d bytes in file %s\r\n",
+				buf_size,
+				fname);
 
-		free(pbuf);
-		pbuf = NULL;
+			free(pbuf);
+			pbuf = NULL;
 
-		goto error;
+			goto error;
+		}
 	}
 
 error:

--- a/vmm/modules/msr_monitor/msr_monitor.c
+++ b/vmm/modules/msr_monitor/msr_monitor.c
@@ -381,7 +381,8 @@ static void msr_monitor_gcpu_init(guest_cpu_handle_t gcpu, UNUSED void *pv)
 	D(VMM_ASSERT(p_guest_msr_mon->msr_bitmap));
 
 	msr_bitmap = (uint64_t)p_guest_msr_mon->msr_bitmap;
-	hmm_hva_to_hpa(msr_bitmap, &msr_bitmap, NULL);
+	VMM_ASSERT_EX(hmm_hva_to_hpa(msr_bitmap, &msr_bitmap, NULL),
+		"MSR bitmap page for guest %d is invalid\n", gcpu->guest->id);
 	vmcs_write(p_vmcs, VMCS_MSR_BITMAP, msr_bitmap);
 }
 

--- a/vmm/utils/heap.c
+++ b/vmm/utils/heap.c
@@ -413,7 +413,7 @@ static void *pool_alloc_internal(pool_node_t *node, uint8_t block_num)
 	block_id = find_avail_block(node, block_num);
 	local_print("POOL: find available block id: %d\n", block_id);
 
-	if (block_id < POOL_BLOCK_NUM_IN_NODE) {
+	if (block_id < (POOL_BLOCK_NUM_IN_NODE - 1)) {
 		/* validity check */
 		VMM_ASSERT_EX(((block_id + node->cont_num_array[block_id]) <= POOL_BLOCK_NUM_IN_NODE),
 			"POOL: the continuous block count(%u) in block(%u) is invalid\n",


### PR DESCRIPTION
1. fix potential buffer overflow in heap.c
2. add assert when do hva_to_hpa in msr_monitor.c
3. fix unchecked return of fread()

Signed-off-by: Yadong Qi <yadong.qi@intel.com>